### PR TITLE
Add constructor functions for DirectDebit and Document

### DIFF
--- a/ct/document.go
+++ b/ct/document.go
@@ -63,3 +63,10 @@ type Amount struct {
 type RemittanceInformation struct {
 	Unstructured string `xml:"Ustrd"` // Unstructured contains free-form remittance information.
 }
+
+func NewDocument(customerCreditTransferInitiation CustomerCreditTransferInitiation) Document {
+	return Document{
+		XMLNS:                            "urn:iso:std:iso:20022:tech:xsd:pain.001.001.03",
+		CustomerCreditTransferInitiation: customerCreditTransferInitiation,
+	}
+}

--- a/dd/document.go
+++ b/dd/document.go
@@ -129,3 +129,10 @@ type DirectDebit struct {
 	Xmlns                         string                        `xml:"xmlns,attr"`
 	CustomerDirectDebitInitiation CustomerDirectDebitInitiation `xml:"CstmrDrctDbtInitn"`
 }
+
+func NewDocument(customerDirectDebitInitiation CustomerDirectDebitInitiation) DirectDebit {
+	return DirectDebit{
+		Xmlns:                         "urn:iso:std:iso:20022:tech:xsd:pain.008.001.02",
+		CustomerDirectDebitInitiation: customerDirectDebitInitiation,
+	}
+}


### PR DESCRIPTION
Introduce new functions `NewDocument` in both `dd/document.go` and `ct/document.go` files to simplify the instantiation of `DirectDebit` and `Document` structs respectively. These functions set default XML namespace values and accept specific initiation structures as parameters.