### PR TITLE
Add 'omitempty' to XML struct tags

### DIFF
--- a/ct/document.go
+++ b/ct/document.go
@@ -8,60 +8,60 @@ import (
 
 // Document represents the root of the XML structure with the required namespaces.
 type Document struct {
-	XMLName                          xml.Name                         `xml:"Document"`
-	XMLNS                            string                           `xml:"xmlns,attr"`
-	CustomerCreditTransferInitiation CustomerCreditTransferInitiation `xml:"CstmrCdtTrfInitn"`
+	XMLName                          xml.Name                         `xml:"Document,omitempty"`
+	XMLNS                            string                           `xml:"xmlns,attr,omitempty"`
+	CustomerCreditTransferInitiation CustomerCreditTransferInitiation `xml:"CstmrCdtTrfInitn,omitempty"`
 }
 
 // CustomerCreditTransferInitiation represents the root of the customer credit transfer initiation.
 type CustomerCreditTransferInitiation struct {
-	GroupHeader pain.GroupHeader `xml:"GrpHdr"`
-	PaymentInfo []PaymentInfo    `xml:"PmtInf"`
+	GroupHeader pain.GroupHeader `xml:"GrpHdr,omitempty"`
+	PaymentInfo []PaymentInfo    `xml:"PmtInf,omitempty"`
 }
 
 // PaymentInfo represents payment-related information.
 type PaymentInfo struct {
-	PaymentInfoID             string                        `xml:"PmtInfId"`    // PaymentInfoID is a unique identifier for the payment info block.
-	PaymentMethod             string                        `xml:"PmtMtd"`      // PaymentMethod defines the payment method (e.g., TRF for Transfer).
-	BatchBooking              bool                          `xml:"BtchBookg"`   // BatchBooking defines whether batch booking is enabled.
-	PaymentTypeInfo           pain.PaymentTypeInfo          `xml:"PmtTpInf"`    // PaymentTypeInfo provides additional payment type information.
-	RequestedExecutionDate    string                        `xml:"ReqdExctnDt"` // RequestedExecutionDate is the date on which the payment should be executed.
-	Debtor                    pain.Party                    `xml:"Dbtr"`        // Debtor contains information about the party sending the payment.
-	DebtorAccount             pain.Account                  `xml:"DbtrAcct"`    // DebtorAccount represents the account of the debtor.
-	DebtorAgent               FinancialInstitution          `xml:"DbtrAgt"`     // DebtorAgent represents the financial institution of the debtor.
-	CreditTransferTransaction CreditTransferTransactionInfo `xml:"CdtTrfTxInf"` // CreditTransferTransaction contains details of the credit transfer.
+	PaymentInfoID             string                        `xml:"PmtInfId,omitempty"`    // PaymentInfoID is a unique identifier for the payment info block.
+	PaymentMethod             string                        `xml:"PmtMtd,omitempty"`      // PaymentMethod defines the payment method (e.g., TRF for Transfer).
+	BatchBooking              bool                          `xml:"BtchBookg,omitempty"`   // BatchBooking defines whether batch booking is enabled.
+	PaymentTypeInfo           pain.PaymentTypeInfo          `xml:"PmtTpInf,omitempty"`    // PaymentTypeInfo provides additional payment type information.
+	RequestedExecutionDate    string                        `xml:"ReqdExctnDt,omitempty"` // RequestedExecutionDate is the date on which the payment should be executed.
+	Debtor                    pain.Party                    `xml:"Dbtr,omitempty"`        // Debtor contains information about the party sending the payment.
+	DebtorAccount             pain.Account                  `xml:"DbtrAcct,omitempty"`    // DebtorAccount represents the account of the debtor.
+	DebtorAgent               FinancialInstitution          `xml:"DbtrAgt,omitempty"`     // DebtorAgent represents the financial institution of the debtor.
+	CreditTransferTransaction CreditTransferTransactionInfo `xml:"CdtTrfTxInf,omitempty"` // CreditTransferTransaction contains details of the credit transfer.
 }
 
 // FinancialInstitution represents the financial institution.
 type FinancialInstitution struct {
-	FinancialInstitutionID FinancialInstitutionID `xml:"FinInstnId"` // FinancialInstitutionID holds the BIC of the institution.
+	FinancialInstitutionID FinancialInstitutionID `xml:"FinInstnId,omitempty"` // FinancialInstitutionID holds the BIC of the institution.
 }
 
 // FinancialInstitutionID represents the BIC code of a financial institution.
 type FinancialInstitutionID struct {
-	BIC string `xml:"BIC"` // BIC is the Bank Identifier Code.
+	BIC string `xml:"BIC,omitempty"` // BIC is the Bank Identifier Code.
 }
 
 // CreditTransferTransactionInfo contains information about a single credit transfer transaction.
 type CreditTransferTransactionInfo struct {
-	PaymentID       pain.PaymentID        `xml:"PmtId"`              // PaymentID contains payment identifiers like instruction ID.
-	PaymentTypeInfo pain.PaymentTypeInfo  `xml:"PmtTpInf,omitempty"` // PaymentTypeInfo is optional payment type information.
-	Amount          Amount                `xml:"Amt"`                // Amount represents the instructed amount for the transfer.
-	CreditorAgent   FinancialInstitution  `xml:"CdtrAgt"`            // CreditorAgent is the financial institution of the creditor.
-	Creditor        pain.Party            `xml:"Cdtr"`               // Creditor contains information about the party receiving the payment.
-	CreditorAccount pain.Account          `xml:"CdtrAcct"`           // CreditorAccount represents the account of the creditor.
-	RemittanceInfo  RemittanceInformation `xml:"RmtInf"`             // RemittanceInfo contains the remittance details.
+	PaymentID       pain.PaymentID        `xml:"PmtId,omitempty"`              // PaymentID contains payment identifiers like instruction ID.
+	PaymentTypeInfo pain.PaymentTypeInfo  `xml:"PmtTpInf,omitempty,omitempty"` // PaymentTypeInfo is optional payment type information.
+	Amount          Amount                `xml:"Amt,omitempty"`                // Amount represents the instructed amount for the transfer.
+	CreditorAgent   FinancialInstitution  `xml:"CdtrAgt,omitempty"`            // CreditorAgent is the financial institution of the creditor.
+	Creditor        pain.Party            `xml:"Cdtr,omitempty"`               // Creditor contains information about the party receiving the payment.
+	CreditorAccount pain.Account          `xml:"CdtrAcct,omitempty"`           // CreditorAccount represents the account of the creditor.
+	RemittanceInfo  RemittanceInformation `xml:"RmtInf,omitempty"`             // RemittanceInfo contains the remittance details.
 }
 
 // Amount represents the amount of money in a transaction.
 type Amount struct {
-	InstructedAmount decimal.Decimal `xml:",chardata"` // InstructedAmount is the amount of money to be transferred.
-	Currency         string          `xml:"Ccy,attr"`  // Currency defines the currency of the instructed amount.
+	InstructedAmount decimal.Decimal `xml:",chardata,omitempty"` // InstructedAmount is the amount of money to be transferred.
+	Currency         string          `xml:"Ccy,attr,omitempty"`  // Currency defines the currency of the instructed amount.
 }
 
 // RemittanceInformation contains remittance details for the transaction.
 type RemittanceInformation struct {
-	Unstructured string `xml:"Ustrd"` // Unstructured contains free-form remittance information.
+	Unstructured string `xml:"Ustrd,omitempty"` // Unstructured contains free-form remittance information.
 }
 
 func NewDocument(customerCreditTransferInitiation CustomerCreditTransferInitiation) Document {

--- a/dd/document.go
+++ b/dd/document.go
@@ -8,126 +8,126 @@ import (
 
 // LocalInstrument represents a local instrument code used in the payment type information.
 type LocalInstrument struct {
-	Code string `xml:"Cd"`
+	Code string `xml:"Cd,omitempty"`
 }
 
 // Creditor represents a creditor in a payment order.
 type Creditor struct {
-	Name          string        `xml:"Nm"`
-	PostalAddress PostalAddress `xml:"PstlAdr"`
+	Name          string        `xml:"Nm,omitempty"`
+	PostalAddress PostalAddress `xml:"PstlAdr,omitempty"`
 }
 
 // CreditorAgent represents the creditor agent information in a direct debit order.
 type CreditorAgent struct {
-	FinancialInstitutionIdentification FinancialInstitutionIdentification `xml:"FinInstnId"`
+	FinancialInstitutionIdentification FinancialInstitutionIdentification `xml:"FinInstnId,omitempty"`
 }
 
 type SchemeName struct {
-	Proprietary string `xml:"Prtry"`
+	Proprietary string `xml:"Prtry,omitempty"`
 }
 
 type Other struct {
-	ID         string     `xml:"Id"`
-	SchemeName SchemeName `xml:"SchmeNm"`
+	ID         string     `xml:"Id,omitempty"`
+	SchemeName SchemeName `xml:"SchmeNm,omitempty"`
 }
 
 // PrivateIdentification is a type that represents private identification information for a specific scheme.
 type PrivateIdentification struct {
-	Other Other `xml:"Othr"`
+	Other Other `xml:"Othr,omitempty"`
 }
 
 // ID represents an identification element in XML, containing the PrivateIdentification element.
 type ID struct {
-	PrivateIdentification PrivateIdentification `xml:"PrvtId"`
+	PrivateIdentification PrivateIdentification `xml:"PrvtId,omitempty"`
 }
 
 // CreditorSchemeIdentification represents the identification of the creditor's scheme.
 type CreditorSchemeIdentification struct {
-	ID ID `xml:"Id"`
+	ID ID `xml:"Id,omitempty"`
 }
 
 // InstigatedAmount represents the amount of an instigated order, including the currency and the textual representation.
 type InstigatedAmount struct {
-	Currency string          `xml:"Ccy,attr"`
-	Text     decimal.Decimal `xml:",chardata"`
+	Currency string          `xml:"Ccy,attr,omitempty"`
+	Text     decimal.Decimal `xml:",chardata,omitempty"`
 }
 
 // MandateRelatedInformation is a type that represents information related to a mandate.
 type MandateRelatedInformation struct {
-	MandateID       string `xml:"MndtId"`
-	DateOfSignature string `xml:"DtOfSgntr"`
+	MandateID       string `xml:"MndtId,omitempty"`
+	DateOfSignature string `xml:"DtOfSgntr,omitempty"`
 }
 
 // DirectDebitTransaction represents a direct debit order in an XML document.
 type DirectDebitTransaction struct {
-	MandateRelatedInformation MandateRelatedInformation `xml:"MndtRltdInf"`
+	MandateRelatedInformation MandateRelatedInformation `xml:"MndtRltdInf,omitempty"`
 }
 
 // FinancialInstitutionIdentification represents the identification of a financial institution.
 type FinancialInstitutionIdentification struct {
-	BICFI string `xml:"BICFI"`
+	BICFI string `xml:"BICFI,omitempty"`
 }
 
 // DebtorAgent represents the debtor's financial institution identification.
 type DebtorAgent struct {
-	FinancialInstitutionIdentification FinancialInstitutionIdentification `xml:"FinInstnId"`
+	FinancialInstitutionIdentification FinancialInstitutionIdentification `xml:"FinInstnId,omitempty"`
 }
 
 // PostalAddress represents a postal address.
 type PostalAddress struct {
-	TownName   string `xml:"TwnNm"`
-	Country    string `xml:"Ctry"`
-	StreetName string `xml:"StrtNm"`
-	PostalCode string `xml:"PstCd"`
+	TownName   string `xml:"TwnNm,omitempty"`
+	Country    string `xml:"Ctry,omitempty"`
+	StreetName string `xml:"StrtNm,omitempty"`
+	PostalCode string `xml:"PstCd,omitempty"`
 }
 
 // Debtor represents a debtor in a Direct Debit order.
 type Debtor struct {
-	Name          string        `xml:"Nm"`
-	PostalAddress PostalAddress `xml:"PstlAdr"`
+	Name          string        `xml:"Nm,omitempty"`
+	PostalAddress PostalAddress `xml:"PstlAdr,omitempty"`
 }
 
 // RemittanceInformation represents the remittance information for a payment order.
 type RemittanceInformation struct {
-	Unstructured string `xml:"Ustrd"`
+	Unstructured string `xml:"Ustrd,omitempty"`
 }
 
 // DirectDebitTransactionInformation represents information about a direct debit order.
 type DirectDebitTransactionInformation struct {
-	PaymentID              pain.PaymentID         `xml:"PmtId"`
-	InstigatedAmount       InstigatedAmount       `xml:"InstdAmt"`
-	DirectDebitTransaction DirectDebitTransaction `xml:"DrctDbtTx"`
-	DebtorAgent            DebtorAgent            `xml:"DbtrAgt"`
-	Debtor                 Debtor                 `xml:"Dbtr"`
-	DebtorAccount          pain.Account           `xml:"DbtrAcct"`
-	RemittanceInformation  RemittanceInformation  `xml:"RmtInf"`
+	PaymentID              pain.PaymentID         `xml:"PmtId,omitempty"`
+	InstigatedAmount       InstigatedAmount       `xml:"InstdAmt,omitempty"`
+	DirectDebitTransaction DirectDebitTransaction `xml:"DrctDbtTx,omitempty"`
+	DebtorAgent            DebtorAgent            `xml:"DbtrAgt,omitempty"`
+	Debtor                 Debtor                 `xml:"Dbtr,omitempty"`
+	DebtorAccount          pain.Account           `xml:"DbtrAcct,omitempty"`
+	RemittanceInformation  RemittanceInformation  `xml:"RmtInf,omitempty"`
 }
 
 // PaymentInformation represents the payment information for a direct debit order.
 type PaymentInformation struct {
-	PaymentInformationId              string                              `xml:"PmtInfId"`
-	PaymentMethod                     string                              `xml:"PmtMtd"`
-	NumberOfTransactions              string                              `xml:"NbOfTxs"`
-	ControlSum                        decimal.Decimal                     `xml:"CtrlSum"`
-	PaymentTypeInformation            pain.PaymentTypeInfo                `xml:"PmtTpInf"`
-	RequestedCollectionDate           string                              `xml:"ReqdColltnDt"`
-	Creditor                          Creditor                            `xml:"Cdtr"`
-	CreditorAccount                   pain.Account                        `xml:"CdtrAcct"`
-	CreditorAgent                     CreditorAgent                       `xml:"CdtrAgt"`
-	CreditorSchemeIdentification      CreditorSchemeIdentification        `xml:"CdtrSchmeId"`
-	DirectDebitTransactionInformation []DirectDebitTransactionInformation `xml:"DrctDbtTxInf"`
+	PaymentInformationId              string                              `xml:"PmtInfId,omitempty"`
+	PaymentMethod                     string                              `xml:"PmtMtd,omitempty"`
+	NumberOfTransactions              string                              `xml:"NbOfTxs,omitempty"`
+	ControlSum                        decimal.Decimal                     `xml:"CtrlSum,omitempty"`
+	PaymentTypeInformation            pain.PaymentTypeInfo                `xml:"PmtTpInf,omitempty"`
+	RequestedCollectionDate           string                              `xml:"ReqdColltnDt,omitempty"`
+	Creditor                          Creditor                            `xml:"Cdtr,omitempty"`
+	CreditorAccount                   pain.Account                        `xml:"CdtrAcct,omitempty"`
+	CreditorAgent                     CreditorAgent                       `xml:"CdtrAgt,omitempty"`
+	CreditorSchemeIdentification      CreditorSchemeIdentification        `xml:"CdtrSchmeId,omitempty"`
+	DirectDebitTransactionInformation []DirectDebitTransactionInformation `xml:"DrctDbtTxInf,omitempty"`
 }
 
 type CustomerDirectDebitInitiation struct {
-	GroupHeader        pain.GroupHeader   `xml:"GrpHdr"`
-	PaymentInformation PaymentInformation `xml:"PmtInf"`
+	GroupHeader        pain.GroupHeader   `xml:"GrpHdr,omitempty"`
+	PaymentInformation PaymentInformation `xml:"PmtInf,omitempty"`
 }
 
 // DirectDebit represents a direct debit document that is used in the context of payment initiation.
 type DirectDebit struct {
-	XMLName                       xml.Name                      `xml:"Document"`
-	Xmlns                         string                        `xml:"xmlns,attr"`
-	CustomerDirectDebitInitiation CustomerDirectDebitInitiation `xml:"CstmrDrctDbtInitn"`
+	XMLName                       xml.Name                      `xml:"Document,omitempty"`
+	Xmlns                         string                        `xml:"xmlns,attr,omitempty"`
+	CustomerDirectDebitInitiation CustomerDirectDebitInitiation `xml:"CstmrDrctDbtInitn,omitempty"`
 }
 
 func NewDocument(customerDirectDebitInitiation CustomerDirectDebitInitiation) DirectDebit {

--- a/pain/document.go
+++ b/pain/document.go
@@ -27,54 +27,54 @@ func (c *CreationDateTime) UnmarshalXML(d *xml.Decoder, start xml.StartElement) 
 
 // GroupHeader contains details about the group of transactions.
 type GroupHeader struct {
-	MessageID            string           `xml:"MsgId"`    // MessageID is a unique identifier for the message.
-	CreationDateTime     CreationDateTime `xml:"CreDtTm"`  // CreationDateTime indicates when the message was created.
-	NumberOfTransactions int              `xml:"NbOfTxs"`  // NumberOfTransactions is the total number of transactions.
-	ControlSum           decimal.Decimal  `xml:"CtrlSum"`  // ControlSum is the total amount for the transaction batch.
-	InitiatingParty      InitiatingParty  `xml:"InitgPty"` // InitiatingParty provides details of the party initiating the transaction.
+	MessageID            string           `xml:"MsgId,omitempty"`    // MessageID is a unique identifier for the message.
+	CreationDateTime     CreationDateTime `xml:"CreDtTm,omitempty"`  // CreationDateTime indicates when the message was created.
+	NumberOfTransactions int              `xml:"NbOfTxs,omitempty"`  // NumberOfTransactions is the total number of transactions.
+	ControlSum           decimal.Decimal  `xml:"CtrlSum,omitempty"`  // ControlSum is the total amount for the transaction batch.
+	InitiatingParty      InitiatingParty  `xml:"InitgPty,omitempty"` // InitiatingParty provides details of the party initiating the transaction.
 }
 
 // InitiatingParty holds information about the party initiating the transaction.
 type InitiatingParty struct {
-	Name string `xml:"Nm"` // Name is the name of the initiating party.
+	Name string `xml:"Nm,omitempty"` // Name is the name of the initiating party.
 }
 
 // Account represents the account details of the debtor or creditor.
 type Account struct {
-	ID       AccountID `xml:"Id"`  // ID contains account identification (e.g., IBAN).
-	Currency string    `xml:"Ccy"` // Currency represents the account's currency (e.g., EUR).
+	ID       AccountID `xml:"Id,omitempty"`  // ID contains account identification (e.g., IBAN).
+	Currency string    `xml:"Ccy,omitempty"` // Currency represents the account's currency (e.g., EUR).
 }
 
 // AccountID contains the IBAN information.
 type AccountID struct {
-	IBAN string `xml:"IBAN"` // IBAN represents the International Bank Account Number.
+	IBAN string `xml:"IBAN,omitempty"` // IBAN represents the International Bank Account Number.
 }
 
 // Party represents the party that sends or receives the payment.
 type Party struct {
-	Name          string        `xml:"Nm"`      // Name is the name of the debtor.
-	PostalAddress PostalAddress `xml:"PstlAdr"` // PostalAddress contains the address of the debtor.
+	Name          string        `xml:"Nm,omitempty"`      // Name is the name of the debtor.
+	PostalAddress PostalAddress `xml:"PstlAdr,omitempty"` // PostalAddress contains the address of the debtor.
 }
 
 // PostalAddress represents the postal address of the debtor or creditor.
 type PostalAddress struct {
-	Country     string   `xml:"Ctry"`    // Country is the country code (e.g., NL for Netherlands).
-	AddressLine []string `xml:"AdrLine"` // AddressLine represents the lines of the address.
+	Country     string   `xml:"Ctry,omitempty"`    // Country is the country code (e.g., NL for Netherlands).
+	AddressLine []string `xml:"AdrLine,omitempty"` // AddressLine represents the lines of the address.
 }
 
 // PaymentTypeInfo contains information about the priority and service level.
 type PaymentTypeInfo struct {
-	InstructionPriority string       `xml:"InstrPrty"` // InstructionPriority indicates the priority of the instruction (e.g., NORM).
-	ServiceLevel        ServiceLevel `xml:"SvcLvl"`    // ServiceLevel defines the service level (e.g., SEPA).
+	InstructionPriority string       `xml:"InstrPrty,omitempty"` // InstructionPriority indicates the priority of the instruction (e.g., NORM).
+	ServiceLevel        ServiceLevel `xml:"SvcLvl,omitempty"`    // ServiceLevel defines the service level (e.g., SEPA).
 }
 
 // ServiceLevel represents the service level code (e.g., SEPA).
 type ServiceLevel struct {
-	Code string `xml:"Cd"` // Code is the code for the service level.
+	Code string `xml:"Cd,omitempty"` // Code is the code for the service level.
 }
 
 // PaymentID represents the identifiers for a payment.
 type PaymentID struct {
-	InstructionID string `xml:"InstrId"`    // InstructionID is the instruction identifier.
-	EndToEndID    string `xml:"EndToEndId"` // EndToEndID is the unique end-to-end transaction identifier.
+	InstructionID string `xml:"InstrId,omitempty"`    // InstructionID is the instruction identifier.
+	EndToEndID    string `xml:"EndToEndId,omitempty"` // EndToEndID is the unique end-to-end transaction identifier.
 }


### PR DESCRIPTION
This change ensures that fields with empty values are omitted from the XML output, reducing unnecessary verbosity and ensuring compatibility with systems that expect only populated fields. It improves the flexibility of XML serialization by making the output more efficient and concise.