### PR TITLE
Update struct fields to use pointers for optional data

### DIFF
--- a/ct/document.go
+++ b/ct/document.go
@@ -49,7 +49,7 @@ type CreditTransferTransactionInfo struct {
 	PaymentID       pain.PaymentID        `xml:"PmtId,omitempty"`    // PaymentID contains payment identifiers like instruction ID.
 	PaymentTypeInfo pain.PaymentTypeInfo  `xml:"PmtTpInf,omitempty"` // PaymentTypeInfo is optional payment type information.
 	Amount          Amount                `xml:"Amt,omitempty"`      // Amount represents the instructed amount for the transfer.
-	CreditorAgent   FinancialInstitution  `xml:"CdtrAgt,omitempty"`  // CreditorAgent is the financial institution of the creditor.
+	CreditorAgent   *FinancialInstitution `xml:"CdtrAgt,omitempty"`  // CreditorAgent is the financial institution of the creditor.
 	Creditor        pain.Party            `xml:"Cdtr,omitempty"`     // Creditor contains information about the party receiving the payment.
 	CreditorAccount pain.Account          `xml:"CdtrAcct,omitempty"` // CreditorAccount represents the account of the creditor.
 	RemittanceInfo  RemittanceInformation `xml:"RmtInf,omitempty"`   // RemittanceInfo contains the remittance details.

--- a/pain/document.go
+++ b/pain/document.go
@@ -52,8 +52,8 @@ type AccountID struct {
 
 // Party represents the party that sends or receives the payment.
 type Party struct {
-	Name          string        `xml:"Nm,omitempty"`      // Name is the name of the debtor.
-	PostalAddress PostalAddress `xml:"PstlAdr,omitempty"` // PostalAddress contains the address of the debtor.
+	Name          string         `xml:"Nm,omitempty"`      // Name is the name of the debtor.
+	PostalAddress *PostalAddress `xml:"PstlAdr,omitempty"` // PostalAddress contains the address of the debtor.
 }
 
 // PostalAddress represents the postal address of the debtor or creditor.


### PR DESCRIPTION
Changed the PostalAddress in the pain document and CreditorAgent in the ct document to use pointer types. This ensures that optional fields are properly represented and allows for nil checks.