### PR TITLE
Change PaymentTypeInfo to a pointer in CreditTransferTransactionInfo

### DIFF
--- a/ct/document.go
+++ b/ct/document.go
@@ -47,7 +47,7 @@ type FinancialInstitutionID struct {
 // CreditTransferTransactionInfo contains information about a single credit transfer transaction.
 type CreditTransferTransactionInfo struct {
 	PaymentID       pain.PaymentID        `xml:"PmtId,omitempty"`    // PaymentID contains payment identifiers like instruction ID.
-	PaymentTypeInfo pain.PaymentTypeInfo  `xml:"PmtTpInf,omitempty"` // PaymentTypeInfo is optional payment type information.
+	PaymentTypeInfo *pain.PaymentTypeInfo `xml:"PmtTpInf,omitempty"` // PaymentTypeInfo is optional payment type information.
 	Amount          Amount                `xml:"Amt,omitempty"`      // Amount represents the instructed amount for the transfer.
 	CreditorAgent   *FinancialInstitution `xml:"CdtrAgt,omitempty"`  // CreditorAgent is the financial institution of the creditor.
 	Creditor        pain.Party            `xml:"Cdtr,omitempty"`     // Creditor contains information about the party receiving the payment.


### PR DESCRIPTION
This pull request includes a small change to the `CreditTransferTransactionInfo` struct in the `ct/document.go` file. The change modifies the `PaymentTypeInfo` field to be a pointer type.

* [`ct/document.go`](diffhunk://#diff-5f607854c67027dc1d9bf8b737c48b3e8c9ebaabc902d50830702aafae11c616L50-R50): Changed the `PaymentTypeInfo` field in the `CreditTransferTransactionInfo` struct to a pointer type (`*pain.PaymentTypeInfo`).